### PR TITLE
Add MIT license, document dependency licensing, and set project license metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 IFUM contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ We thank those who support open science. Without them, developing IFUM was impos
     - [Command-line Arguments](#command-line-arguments)
     - [Targeting a Specific GPU](#targeting-a-specific-gpu)
 - [Output CSV File](#output-csv-file)
+- [License](#license)
 - [(very important) Known Limitations](#known-limitations)
 
 ## Citation
@@ -166,6 +167,14 @@ name,dG(kcal/mol)
 MyUb_WT,0.20
 MyUb_R1117A,-0.05
 ```
+
+## License
+
+This project is released under the [MIT License](LICENSE).
+
+### Third-party dependencies
+
+IFUM uses third-party components, including ESM and ProtT5. The MIT license for IFUM applies to the code in this repository, while each third-party dependency keeps its own license terms. If you redistribute IFUM, you should also comply with the license requirements of all bundled or installed dependencies.
 
 ## Known Limitations
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ version = "1.0.0"
 description = "In silico Evaluation of Unfolding Free Energy with Unfolded states Modeling"
 readme = "README.md"
 requires-python = ">=3.9"
+license = {text = "MIT"}
 
 [tools.setuptools.packages.find]
 where = ["src"]


### PR DESCRIPTION
### Motivation
- Provide an explicit repository license required for institutional approval and clarify how third-party component licenses relate to the project.
- Make the project metadata reflect the chosen license so packaging/indexing tools can surface license information.

### Description
- Add a top-level `LICENSE` file containing the MIT license with the copyright line `Copyright (c) 2026 IFUM contributors`.
- Add a `License` section to `README.md` that states the project is released under the MIT license and explicitly notes that third-party components (e.g., ESM and ProtT5) keep their own license terms.
- Add `license = {text = "MIT"}` to `pyproject.toml` so the package metadata declares the license.
- Make a small formatting fix to ensure `pyproject.toml` ends with a newline.

### Testing
- Ran `git diff -- README.md pyproject.toml LICENSE` and inspected the resulting diffs to confirm the intended changes were applied (succeeded).
- Ran `python --version` which returned `Python 3.10.19` (succeeded).
- Attempted to parse `pyproject.toml` using `tomllib` via `python -c` to validate TOML loading, which failed because the environment Python lacks `tomllib` (test failed but unrelated to file contents).
- Printed and reviewed the updated file contents with `nl` to verify the `LICENSE`, `README.md`, and `pyproject.toml` changes (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf5a6943e8832187dbc50ce92140d6)